### PR TITLE
Adding a logCommand method

### DIFF
--- a/logging_test/TestHelper.m
+++ b/logging_test/TestHelper.m
@@ -33,8 +33,14 @@ classdef TestHelper < handle
             end
         end
 
-        function verifyLogEntry(testCase, logFile, logString)
-            fileData = TestHelper.getFileData(testCase, logFile);
+        function verifyLogEntry(testCase, logFile, logString, varargin)
+            if nargin > 3
+                options = varargin;
+            else
+                options = {};
+            end
+
+            fileData = TestHelper.getFileData(testCase, logFile, options{:});
             testCase.verifySubstring(fileData, logString);
         end
 
@@ -48,9 +54,38 @@ classdef TestHelper < handle
             testCase.verifyEqual(fgetLReturnValue, -1);
         end
 
-        function fileData = getFileData(testCase, logFile)
+        function verifyNumLinesInLog(testCase, logFile, numLines)
             fd = fopen(logFile);
-            fileData = fgetl(fd);
+            actualLines = 0;
+            tline = fgets(fd);
+            while tline ~= -1
+                actualLines = actualLines + 1;
+                tline = fgets(fd);
+            end
+            fclose(fd);
+
+            testCase.verifyEqual(actualLines, numLines);
+        end
+
+        function fileData = getFileData(testCase, logFile, varargin)
+            if nargin > 2
+                options = struct(varargin{:});
+            else
+                options = struct();
+            end
+
+            if isfield(options, 'lineNum')
+                lineNum = options.lineNum;
+            else
+                lineNum = 1;
+            end
+
+            fd = fopen(logFile);
+            currentLine = 0;
+            while currentLine < lineNum
+                fileData = fgetl(fd);
+                currentLine = currentLine + 1;
+            end
             fclose(fd);
         end
     end


### PR DESCRIPTION
Adding a method that will log a command and all output to standard out.  This feature is not yet ready to be released in the public API, as it has not yet been thoroughly tested.  Even if it were, though, handling scope for all but the simplest use cases makes this method not very elegant to use.

To log a simple command:

```
logger.logCommand('fprintf(''Logging output'')');
```

To log a simple command with output variables assigned:

```
[a, b, c] = logger.logCommand('deal(1)');
```

Scope is not shared when you call `logCommand`.  So if you need to share scope, you must pass the scope into the `logCommand` method.  You can do so as a string:

```
x = logger.logCommand( ...
    'fmincon(fun,x0,A,b)', ...
    'fun = @(x)100*(x(2)-x(1)^2)^2, x0 = [-1,2], A = [1,2], b = 1' ...
);
```

Or as a list of variables:

```
fun = @(x)100*(x(2)-x(1)^2)^2 + (1-x(1))^2;
x0 = [-1,2];
A = [1,2];
b = 1;

x = logger.logCommand('fmincon(fun,x0,A,b)', fun, x0, A, b);
```
