### PR TITLE
Correcting varargin processing

### DIFF
--- a/+logging/configureLogging.m
+++ b/+logging/configureLogging.m
@@ -140,7 +140,7 @@ function options = getOptions(varargin)
         if argumentsAreInStruct(varargin{:})
             options = varargin{1};
         elseif argumentsAreInClassicMatlabStyle(varargin{:})
-            options = struct(varargin{:});
+            options = cell2struct({varargin{2:2:end}}, {varargin{1:2:end}}, 2);
         else
             throw(MException( ...
                 'logging:InvalidArguments',  ...

--- a/logging_test/TestHelper.m
+++ b/logging_test/TestHelper.m
@@ -68,11 +68,7 @@ classdef TestHelper < handle
         end
 
         function fileData = getFileData(testCase, logFile, varargin)
-            if nargin > 2
-                options = struct(varargin{:});
-            else
-                options = struct();
-            end
+            options = cell2struct({varargin{2:2:end}}, {varargin{1:2:end}}, 2);
 
             if isfield(options, 'lineNum')
                 lineNum = options.lineNum;


### PR DESCRIPTION
When processing an arbitarary number of inputs, we had previously done this:
```matlab
>> opts = struct(varargin{:});
```
This works great, as long as none of the arguments in the varargin structure
are cell arrays themselves. If this is the case, then processing fails because
the cell array is decomposed along with the varargin cell array, e.g.
```
>> varargin

'labels' [1x2 cell array]

>> varargin{2}

ans =

     'label a'    'label b'

>> foo = struct(varargin{:});
>> foo.labels

ans =

    'label a'

ans =

    'label b'

>> baz = foo.labels

ans =

     'label a'
```
Note that, since the second entry in the varargin structure is a cell array, it
is decomposed when calling varargin{:} and, thus when attempting to assign a
value to baz from foo.labels, only the first label's value is assigned. In
order to do this processing correctly, we need to replace these lines:
```matlab
>> opts = struct(varargin{:});
```
with a call to cell2struct:
```matlab
>> opts = cell2struct({varargin{2:2:end}}, {varargin{1:2:end}}, 1);
```